### PR TITLE
ci: Use correct helper image even if both are built simultaneously

### DIFF
--- a/.github/workflows/inspektor-gadget.yml
+++ b/.github/workflows/inspektor-gadget.yml
@@ -788,8 +788,8 @@ jobs:
     name: helper images
     runs-on: ubuntu-latest
     outputs:
-      dnstester_image: ${{ steps.image-tag.outputs.dnstester || env.DEFAULT_DNSTESTER_IMAGE }}
-      ebpf_builder_image: ${{ steps.image-tag.outputs.ebpf-builder || env.DEFAULT_EBPF_BUILDER_IMAGE }}
+      dnstester_image: ${{ steps.image-tag.outputs.dnstester }}
+      ebpf_builder_image: ${{ steps.image-tag.outputs.ebpf-builder }}
     permissions:
       # allow publishing container image
       # in case of public fork repo/packages permissions will always be read
@@ -855,9 +855,21 @@ jobs:
         platforms: ${{ matrix.image.platform }}
     - name: Save ${{ matrix.image.name }} image tag output
       id: image-tag
-      if: steps.build-image.outputs.digest != ''
       run: |
-        echo "${{ matrix.image.name }}=${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}" >> $GITHUB_OUTPUT
+        if [ -n "${{ steps.build-image.outputs.digest }}" ]; then
+          image="${{ steps.set-repo-determine-image-tag.outputs.container-repo }}:${{ steps.set-repo-determine-image-tag.outputs.image-tag }}"
+        else
+          if [ ${{ matrix.image.name }} == "dnstester" ]; then
+            image=${{ env.DEFAULT_DNSTESTER_IMAGE }}
+          elif [ ${{ matrix.image.name }} == "ebpf-builder" ]; then
+            image=${{ env.DEFAULT_EBPF_BUILDER_IMAGE }}
+          else
+            >&2 echo "No default image for ${{ matrix.image.name }}!" 
+            exit 1
+          fi
+        fi
+
+        echo "${{ matrix.image.name }}=${image}" >> $GITHUB_OUTPUT
 
   build-examples:
     name: example

--- a/Dockerfiles/ebpf-builder.Dockerfile
+++ b/Dockerfiles/ebpf-builder.Dockerfile
@@ -2,6 +2,7 @@ ARG CLANG_LLVM_VERSION=15
 ARG LIBBPF_VERSION=v1.3.0
 ARG TINYGO_VERSION=0.30.0
 
+# test
 # Args need to be redefined on each stage
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 

--- a/tools/dnstester/dnstester.go
+++ b/tools/dnstester/dnstester.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Inspektor Gadget authors
+// Copyright 2024 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes: 5ddb3fb2f173e7873e1d9ce52c416fe055b8e74a

Currently, if both images are built together one of the image will have a default value since we set tag for both the images in each matric run. This change ensures we only set the default value when needed and not in each matric run.